### PR TITLE
ci: bump Go to 1.26.4 in release build metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
           echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "GO_VERSION=1.26.3" >> $GITHUB_ENV
+          echo "GO_VERSION=1.26.4" >> $GITHUB_ENV
 
       - name: Set up Go
         if: github.event_name == 'release' || inputs.build_binaries


### PR DESCRIPTION
Follow-up to #198 — the `GO_VERSION` env in the release workflow's build-metadata step was still pinned to 1.26.3. Bumps it to 1.26.4 to match the rest of the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)